### PR TITLE
Fix #2 data inconsistencies

### DIFF
--- a/lib/LiBro/Data.hs
+++ b/lib/LiBro/Data.hs
@@ -17,6 +17,7 @@ data Person = Person
   } deriving (Show, Generic)
 
 instance Eq Person where (==) = (==) `on` pid
+instance Ord Person where (<=) = (<=) `on` pid
 instance ToJSON Person
 instance FromJSON Person
 instance FromRecord Person

--- a/lib/LiBro/Data/Storage.hs
+++ b/lib/LiBro/Data/Storage.hs
@@ -7,6 +7,7 @@ import LiBro.Util
 import Data.Text (Text)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BS
+import Data.Function
 import Data.Map (Map, (!))
 import qualified Data.Map as M
 import Data.Tree
@@ -52,8 +53,9 @@ data TaskRecord = TaskRecord
   , tTitle        :: Text
   , tDescription  :: Text
   , tAssignees    :: IdList
-  } deriving (Eq, Show, Generic)
+  } deriving (Show, Generic)
 
+instance Eq TaskRecord where (==) = (==) `on` trid
 instance FromRecord TaskRecord
 instance ToRecord TaskRecord
 instance DefaultOrdered TaskRecord

--- a/lib/LiBro/Util.hs
+++ b/lib/LiBro/Util.hs
@@ -8,6 +8,7 @@ import Data.Map as M
 import Data.Tree
 import Data.Maybe
 import Data.Bifunctor
+import Control.Monad.State
 
 -- |  A 'Tree'/'Forest' representation as a linear list.
 --    All entries point to their parent.
@@ -24,3 +25,17 @@ readForest pairs =
   where fill cs n = Node n $ case M.lookup n cs of
                               Nothing -> []; Just [] -> []
                               Just xs -> fill cs <$> sort xs
+
+-- |  Simple monad transformer that allows to read an increasing 'Int'.
+type CountingT m = StateT Int m
+
+-- |  Grabs the next 'Int'.
+next :: Monad m => CountingT m Int
+next = do
+  val <- get
+  modify succ
+  return val
+
+-- |  Evaluate the given action with counting from the given initial value.
+runCountingT :: Monad m => CountingT m a -> Int -> m a
+runCountingT = evalStateT

--- a/libro-backend.cabal
+++ b/libro-backend.cabal
@@ -72,6 +72,7 @@ test-suite libro-backend-test
                     , silently
                     , temporary
                     , text
+                    , transformers
                     , vector
                     , xlsx
   build-tool-depends: hspec-discover:hspec-discover

--- a/libro-backend.cabal
+++ b/libro-backend.cabal
@@ -49,7 +49,9 @@ test-suite libro-backend-test
   default-extensions: OverloadedStrings
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test
-  other-modules:      LiBro.ConfigSpec
+  other-modules:      LiBro.TestUtil
+                    , LiBro.TestUtilSpec
+                    , LiBro.ConfigSpec
                     , LiBro.DataSpec
                     , LiBro.Data.StorageSpec
                     , LiBro.UtilSpec

--- a/libro-backend.cabal
+++ b/libro-backend.cabal
@@ -31,6 +31,7 @@ library
                     , data-default
                     , directory
                     , filepath
+                    , mtl
                     , process
                     , temporary
                     , text

--- a/test/LiBro/Data/StorageSpec.hs
+++ b/test/LiBro/Data/StorageSpec.hs
@@ -3,8 +3,8 @@ module LiBro.Data.StorageSpec where
 import Test.Hspec
 import Test.QuickCheck
 import Test.Hspec.QuickCheck
-import Data.Text.Arbitrary
 import Test.QuickCheck.Arbitrary.Generic
+import LiBro.TestUtil
 
 import LiBro.Config
 import LiBro.Data

--- a/test/LiBro/Data/StorageSpec.hs
+++ b/test/LiBro/Data/StorageSpec.hs
@@ -9,7 +9,6 @@ import LiBro.TestUtil
 import LiBro.Config
 import LiBro.Data
 import LiBro.Data.Storage
-import LiBro.DataSpec
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.Text as T
 import Data.Maybe
@@ -26,6 +25,7 @@ import System.FilePath
 import System.IO.Temp
 import Control.Monad
 
+-- Beware: Arbitrary Person has pid collisions
 instance Arbitrary Person where
   arbitrary = genericArbitrary
 
@@ -285,10 +285,10 @@ dataStorage = describe "Complete dataset" $ do
   context "With arbitrary datasets" $ do
     modifyMaxSuccess (const 5) $
       prop "load . store = id" $
-        forAll (scale (`div` 30) genPersonsTasks) $ \d -> ioProperty $ do
-          print (length (fst d), length (concatMap flatten (snd d)))
-          withSystemTempDirectory "storage" $ \tdir -> do
-            let conf = def { storage = def { directory = tdir }}
-            storeData conf d
-            loadedData <- loadData conf
-            return $ loadedData === d
+        forAll genPersonsTasks $ \d ->
+          ioProperty $ do
+            withSystemTempDirectory "storage" $ \tdir -> do
+              let conf = def { storage = def { directory = tdir }}
+              storeData conf d
+              loadedData <- loadData conf
+              return $ loadedData `shouldBe` d

--- a/test/LiBro/DataSpec.hs
+++ b/test/LiBro/DataSpec.hs
@@ -4,7 +4,7 @@ import Test.Hspec
 import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
 import Test.Hspec.QuickCheck
-import Data.Text.Arbitrary
+import LiBro.TestUtil
 
 import LiBro.Data
 import Data.List

--- a/test/LiBro/DataSpec.hs
+++ b/test/LiBro/DataSpec.hs
@@ -7,38 +7,7 @@ import Test.Hspec.QuickCheck
 import LiBro.TestUtil
 
 import LiBro.Data
-import Data.List
-import Data.Function
 import Data.Tree
-
--- Person generator with a given person ID.
-genPerson :: Int -> Gen Person
-genPerson pid = Person  <$> return pid
-                        <*> arbitrary
-                        <*> arbitrary
-
--- Unique person lists generator
-genPersons :: Gen [Person]
-genPersons = mapM genPerson =<< arbitrary `suchThat` unique
-  where unique = (==) <*> nub
-
--- Task generator with task ID and _allowed_ persons
-genTask :: [Person] -> Int -> Gen Task
-genTask ps tid = Task <$> return tid
-                      <*> arbitrary
-                      <*> arbitrary
-                      <*> sublistOf ps
-
-genTaskForest :: Gen Task -> Gen (Forest Task)
-genTaskForest = listOf . liftArbitrary
-
--- Generate a full data setting with non-empty persons
--- with unique person ids and tasks with valid assignees
-genPersonsTasks :: Gen ([Person], Tasks)
-genPersonsTasks = do
-  ps <- genPersons `suchThat` (not.null)
-  ts <- genTaskForest $ genTask ps =<< arbitrary
-  return (ps, ts)
 
 spec :: Spec
 spec = describe "Data handling" $ do

--- a/test/LiBro/TestUtil.hs
+++ b/test/LiBro/TestUtil.hs
@@ -1,9 +1,67 @@
 module LiBro.TestUtil where
 
-import Data.Char
+import LiBro.Data
+import LiBro.Util
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.List
+import Data.Tree
+import Data.Bifunctor
 import Test.QuickCheck
+import Control.Monad
+import Control.Monad.Trans.Class
 
 instance Arbitrary Text where
   arbitrary = T.pack . getPrintableString <$> arbitrary
+
+-- Person generator with a given person ID.
+genPerson :: Int -> Gen Person
+genPerson pid = Person  <$> return pid
+                        <*> arbitrary
+                        <*> arbitrary
+
+-- Unique person lists generator
+genPersons :: Gen [Person]
+genPersons = mapM genPerson =<< arbitrary `suchThat` unique
+  where unique = (==) <*> nub
+
+-- Task generator with task ID and _allowed_ persons
+genTask :: [Person] -> Int -> Gen Task
+genTask ps tid = Task <$> return tid
+                      <*> arbitrary
+                      <*> arbitrary
+                      <*> sublistOf ps
+
+-- |  A QuickCheck 'Gen' variant that can count
+--    (helpful for unique IDs).
+type CountingGen = CountingT Gen
+
+scaledListOf :: (Int -> Int) -> CountingGen a -> CountingGen [a]
+scaledListOf s g = do
+  oldSize <- lift $ getSize
+  newSize <- lift $ chooseInt (0, s oldSize)
+  replicateM newSize g
+
+countingGenTaskTree :: [Person] -> CountingGen (Tree Task)
+countingGenTaskTree ps = do
+  tid       <- next
+  task      <- lift $ genTask ps tid
+  children  <- scaledListOf (`div` 50) $ countingGenTaskTree ps
+  return $ Node task children
+
+-- |  Task tree generator with unique IDs and _allowed_ persons
+genTaskTree :: [Person] -> Gen (Tree Task)
+genTaskTree ps = runCountingT (countingGenTaskTree ps) =<< arbitrary
+
+-- |  Task forest generator with unique IDs and _allowed_ persons
+genTaskForest :: [Person] -> Gen Tasks
+genTaskForest ps = runCountingT gtf =<< arbitrary
+  where gtf = scaledListOf (`div` 2) $ countingGenTaskTree ps
+
+-- |  Generate a full data setting with non-empty persons
+--    with unique person ids and tasks with valid assignees
+genPersonsTasks :: Gen ([Person], Tasks)
+genPersonsTasks = do
+  ps <- genPersons `suchThat` (not.null)
+  ts <- genTaskForest ps
+  return (ps, ts)

--- a/test/LiBro/TestUtil.hs
+++ b/test/LiBro/TestUtil.hs
@@ -1,0 +1,9 @@
+module LiBro.TestUtil where
+
+import Data.Char
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.QuickCheck
+
+instance Arbitrary Text where
+  arbitrary = T.pack . getPrintableString <$> arbitrary

--- a/test/LiBro/TestUtilSpec.hs
+++ b/test/LiBro/TestUtilSpec.hs
@@ -5,13 +5,17 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
 import LiBro.TestUtil
+import LiBro.Data
 import Data.Char
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.List
+import Data.Tree
 
 spec :: Spec
 spec = describe "Test utilities" $ do
   arbitraryText
+  dataGeneration
 
 arbitraryText :: Spec
 arbitraryText = describe "Arbitrary instance for Data.Text" $ do
@@ -24,3 +28,42 @@ arbitraryText = describe "Arbitrary instance for Data.Text" $ do
 
   prop "Everything is printable" $  \t ->
     t `shouldSatisfy` T.all isPrint
+
+dataGeneration :: Spec
+dataGeneration = describe "Generation of arbitrary libro data" $ do
+
+  describe "Person generation" $ do
+    prop "Person has the right ID" $ \i ->
+      forAll (genPerson i) $ \p ->
+        pid p `shouldBe` i
+    prop "Person list has unique IDs" $ do
+      forAll genPersons $ \ps -> do
+        let pids = pid <$> ps
+        length (nub pids) `shouldBe` length pids
+
+  describe "Task generation" $ do
+    prop "Task has the right ID" $ \i ->
+      forAll genPersons $ \ps ->
+        forAll (genTask ps i) $ \t ->
+          tid t `shouldBe` i
+    prop "Task tree has unique IDs" $ do
+      forAll genPersons $ \ps ->
+        forAll (genTaskTree ps) $ \tt -> do
+          let tids = tid <$> flatten tt
+          length (nub tids) `shouldBe` length tids
+    prop "Task tree has only allowed assignees" $ do
+      forAll genPersons $ \ps ->
+        forAll (genTaskTree ps) $ \tt ->
+          (`all` concatMap assignees (flatten tt)) $ \p ->
+            p `elem` ps
+    prop "Task forest has unique IDs" $ do
+      forAll genPersons $ \ps ->
+        forAll (genTaskForest ps) $ \tf -> do
+          let tids = tid <$> concatMap flatten tf
+          length (nub tids) `shouldBe` length tids
+    prop "Task forest has only allowed assignees" $ do
+      forAll genPersons $ \ps ->
+        forAll (genTaskForest ps) $ \tf ->
+          let tasks = concatMap flatten tf
+          in  (`all` concatMap assignees tasks) $ \as ->
+                as `elem` ps

--- a/test/LiBro/TestUtilSpec.hs
+++ b/test/LiBro/TestUtilSpec.hs
@@ -1,0 +1,26 @@
+module LiBro.TestUtilSpec where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+import LiBro.TestUtil
+import Data.Char
+import Data.Text (Text)
+import qualified Data.Text as T
+
+spec :: Spec
+spec = describe "Test utilities" $ do
+  arbitraryText
+
+arbitraryText :: Spec
+arbitraryText = describe "Arbitrary instance for Data.Text" $ do
+
+  prop "Non-empty Text generated" $
+    -- Looks like a tautology, but demonstrates that
+    -- the following property is not testing the empty set
+    forAll (arbitrary `suchThat` ((> 42) . length)) $ \ts ->
+      (ts :: [Text]) `shouldSatisfy` not . all T.null
+
+  prop "Everything is printable" $  \t ->
+    t `shouldSatisfy` T.all isPrint

--- a/test/LiBro/UtilSpec.hs
+++ b/test/LiBro/UtilSpec.hs
@@ -1,13 +1,17 @@
 module LiBro.UtilSpec where
 
 import Test.Hspec
+import Test.Hspec.QuickCheck
 
 import LiBro.Util
 import Data.Tree
+import Data.Functor.Identity
+import Control.Monad
 
 spec :: Spec
 spec = describe "Helper stuff" $ do
   forestFromParentList
+  countingT
   
 forestFromParentList :: Spec
 forestFromParentList = describe "Read Forest from parent list" $ do
@@ -21,3 +25,11 @@ forestFromParentList = describe "Read Forest from parent list" $ do
         [ Node 17 [ Node 34 [], Node 51 []]
         , Node 42 [ Node 84 [ Node 168 [] ]]
         ]
+
+countingT :: Spec
+countingT = describe "The CountingT 'monad transformer'" $ do
+  let nextTimes n = replicateM n next
+  describe "Counting from arbitrary Ints" $ do
+    prop "Grab the following Ints" $ \(start, len) -> do
+      let results = runCountingT (nextTimes len) start
+      runIdentity results `shouldBe` take len [start..]


### PR DESCRIPTION
Closes #2

Important steps:

- [x] `Arbitrary Text` could be restricted with QuickCheck's `PrintableString`.
- [x] Our data classes need `Ord` instances to have them deeply sorted for data comparisons
- [x] Some testing magic is neccessary to have unique `Person`s, unique `Task`s and valid `assignees` in test data, otherwise the `Ord` instances might not do the right thing™️.

Useful other changes:

- [x] Move data generators to `LiBro.TestUtil`.